### PR TITLE
Small adjustments to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Need help getting started? See [Contributing to Projects](https://docs.github.co
 
 ## Build requirements
 
-You need Python 3 and tox. Install tox with pip or use the package manager of your choice.
+You need Python 3 and tox 3. Install tox 3.27.1 or earlier with pip or use the package manager of your choice.
 
 ## Building the documentation
 
@@ -24,5 +24,5 @@ will be in the ``build/html`` directory.
 
 ## Build and preview documentation locally
 
-Run ``tox run -e run`` to build the documentation and serve it locally
+Run ``tox -e run`` to build the documentation and serve it locally
 on http://localhost:8000 for preview.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the Binero documentation!
 
 We use the [Sphinx framework](https://www.sphinx-doc.org/en/master/) to create and maintain this documentation.
 
-Contributions is most welcome!
+Contributions are most welcome!
 
 ## Contributions
 
@@ -19,10 +19,10 @@ You need Python 3 and tox. Install tox with pip or use the package manager of yo
 
 ## Building the documentation
 
-Run ``tox -e docs`` that will run sphinx-build and the built documentation
+Run ``tox -e docs`` to run sphinx-build. The built documentation
 will be in the ``build/html`` directory.
 
 ## Build and preview documentation locally
 
-Run ``tox -e run`` that will build the documentation and serve it locally
+Run ``tox run -e run`` to build the documentation and serve it locally
 on http://localhost:8000 for preview.


### PR DESCRIPTION
`tox -e run` did not work for me, but `tox run -e run` did. Updated the readme to reflect this, I hope it is correct. Plus some small grammatical adjustments.