### PR TITLE
Add tox 4 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install tox
         run: sudo apt install tox
       - name: Run tox docs env
-        run: tox -e docs
+        run: tox run -e docs
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,16 @@ jobs:
   test-pep8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install tox
-        run: sudo apt install tox
+        run: sudo apt install -y tox
       - name: Run tox pep8 env
-        run: tox -e pep8
+        run: tox run -e pep8
   test-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install tox
-        run: sudo apt install tox
+        run: sudo apt install -y tox
       - name: Run tox docs env
-        run: tox -e docs
+        run: tox run -e docs

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Need help getting started? See [Contributing to Projects](https://docs.github.co
 
 ## Build requirements
 
-You need Python 3 and tox 3. Install tox 3.27.1 or earlier with pip or use the package manager of your choice.
+You need Python 3 and tox. Install tox with pip or use the package manager of your choice.
 
 ## Building the documentation
 
-Run ``tox -e docs`` to run sphinx-build. The built documentation
+Run ``tox run -e docs`` to run sphinx-build. The built documentation
 will be in the ``build/html`` directory.
 
 ## Build and preview documentation locally
 
-Run ``tox -e run`` to build the documentation and serve it locally
+Run ``tox run -e run`` to build the documentation and serve it locally
 on http://localhost:8000 for preview.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-flake8
-sphinx
-sphinx_immaterial
-sphinx_sitemap
-sphinx-intl
+sphinx # BSD
+sphinx-immaterial # MIT
+sphinx-sitemap # MIT

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+flake8 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.4
+minversion = 3.0
 skipsdist = True
 
 [testenv]
@@ -8,7 +8,8 @@ install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 
 [testenv:pep8]
-commands = flake8 {posargs}
+deps = -r{toxinidir}/test-requirements.txt
+commands = flake8
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
* This does some cleanup and moves test requirements into it's own file.
* Use checkout@v4 to fix node12 warnings.
* Set's minimum tox version to 3.0 where this syntax seems to work as well.
* Adds license info to requirements.
* Remove sphinx-intl that is not used anymore.

Note that this is a little bit of a hack as well to still support tox 3 since using ``tox run`` on there just adds ``run`` to ``{posargs}`` which is wrong but seems to be a workaround to support both.