### PR TITLE
Revert "Pin sphinx<7.3.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-# TODO(tobias.urdin): Unpin sphinx when sphinx-immaterial works
-# with newer versions https://github.com/jbms/sphinx-immaterial/issues/345
-sphinx<7.3.0 # BSD
+sphinx # BSD
 sphinx-immaterial # MIT
 sphinx-sitemap # MIT
 sphinxcontrib-youtube # BSD


### PR DESCRIPTION
Reason: Fixed in sphinx 7.3.6

This reverts commit 9b0ae6deb04fe1517549783e1579ad453d31833b.