### PR TITLE
Add doc about object storage quota

### DIFF
--- a/general/quotas.rst
+++ b/general/quotas.rst
@@ -51,6 +51,8 @@ The default quotas, available out of the box, are as follows:
 
 - Security group rules: 249
 
+- :doc:`Object storage </storage/object-storage/index>` buckets/container: 1000
+
 ..  seealso::
 
   - :doc:`/general/getting-support`

--- a/storage/object-storage/getting-started.rst
+++ b/storage/object-storage/getting-started.rst
@@ -42,6 +42,11 @@ availability zone europe-se-1a if this meets your requirements. Below methods us
    By using any of the below methods, you will create a container/bucket without replication in the
    europe-se-1a availability zone.
 
+.. tip::
+
+   We enforce a default quota of 1000 buckets/container in the object storage, please contact our
+   support if you need more.
+
 Cloud management portal
 -----------------------
 

--- a/storage/object-storage/index.rst
+++ b/storage/object-storage/index.rst
@@ -25,6 +25,11 @@ but use different APIs.
    In the documentation we can refer to either a container or bucket both being the same thing, a container holding
    objects, where bucket is S3 terminology and container is Swift terminology.
 
+.. tip::
+
+   We enforce a default quota of 1000 buckets/container in the object storage, please contact our
+   support if you need more.
+
 You have the ability to chose from several :doc:`storage policies <storage-policy>` of object storage to setup a
 storage solution that delivers at the lowest possible cost per GB while still meeting your requirements.
 


### PR DESCRIPTION
We enforce a default quota of 1000 buckets/containers in the object storage.